### PR TITLE
Lemmas about symmetric closure and symmetry of relations

### DIFF
--- a/HahnEquational.v
+++ b/HahnEquational.v
@@ -1202,6 +1202,9 @@ Section PropertiesSymmetry.
   Implicit Type r : relation A.
   Implicit Type s : A -> Prop.
 
+  Lemma symmetricE r : symmetric r <-> r ≡ r⁻¹.
+  Proof. u. Qed.
+
   Lemma cr_sym r : symmetric r -> symmetric r^?.
   Proof. u. Qed.
 

--- a/HahnEquational.v
+++ b/HahnEquational.v
@@ -46,6 +46,10 @@ Add Parametric Morphism A : (@irreflexive A) with signature
   inclusion --> Basics.impl as irreflexive_mori.
 Proof. u. Qed.
 
+Add Parametric Morphism A : (@clos_refl A) with signature
+  inclusion ==> inclusion as clos_refl_mori.
+Proof. u. Qed.
+
 Add Parametric Morphism A : (@clos_trans A) with signature
   inclusion ==> inclusion as clos_trans_mori.
 Proof. u; eauto using clos_trans_mon. Qed.
@@ -54,9 +58,13 @@ Add Parametric Morphism A : (@clos_refl_trans A) with signature
   inclusion ==> inclusion as clos_refl_trans_mori.
 Proof. u; eauto using clos_refl_trans_mon. Qed.
 
-Add Parametric Morphism A : (@clos_refl A) with signature
-  inclusion ==> inclusion as clos_refl_mori.
-Proof. u. Qed.
+Add Parametric Morphism A : (@clos_sym A) with signature
+  inclusion ==> inclusion as clos_sym_mori.
+Proof. unfold clos_sym. u. Qed.
+
+Add Parametric Morphism A : (@clos_refl_sym A) with signature
+  inclusion ==> inclusion as clos_refl_sym_mori.
+Proof. unfold clos_refl_sym. u. Qed.
 
 Add Parametric Morphism A : (@restr_rel A) with signature
   set_subset ==> inclusion ==> inclusion as restr_rel_mori.
@@ -179,6 +187,10 @@ Add Parametric Morphism A B : (@map_rel A B) with signature
     eq ==> same_relation ==> same_relation as map_rel_more.
 Proof. u. Qed.
 
+Add Parametric Morphism A : (@clos_refl A) with signature
+  same_relation ==> same_relation as clos_relf_more.
+Proof. u. Qed.
+
 Add Parametric Morphism A : (@clos_trans A) with signature
   same_relation ==> same_relation as clos_trans_more.
 Proof. u; eauto using clos_trans_mon. Qed.
@@ -187,9 +199,13 @@ Add Parametric Morphism A : (@clos_refl_trans A) with signature
   same_relation ==> same_relation as clos_refl_trans_more.
 Proof. u; eauto using clos_refl_trans_mon. Qed.
 
-Add Parametric Morphism A : (@clos_refl A) with signature
-  same_relation ==> same_relation as clos_relf_more.
-Proof. u. Qed.
+Add Parametric Morphism A : (@clos_sym A) with signature
+  same_relation  ==> same_relation as clos_sym_more.
+Proof. unfold clos_sym. u. Qed.
+
+Add Parametric Morphism A : (@clos_refl_sym A) with signature
+  same_relation  ==> same_relation as clos_refl_sym_more.
+Proof. unfold clos_refl_sym. u. Qed.
 
 Add Parametric Morphism A : (@irreflexive A) with signature
   same_relation ==> iff as irreflexive_more.
@@ -200,6 +216,10 @@ Add Parametric Morphism A : (@acyclic A) with signature
 Proof.
   unfold acyclic; ins; rewrite H; reflexivity.
 Qed.
+
+Add Parametric Morphism A : (@symmetric A) with signature
+  same_relation ==> iff as symmetric_more.
+Proof. u. Qed.
 
 Add Parametric Morphism A : (@transitive A) with signature
   same_relation ==> iff as transitive_more.
@@ -246,7 +266,6 @@ Proof. u. Qed.
 Add Parametric Morphism A B : (@collect_rel A B) with signature 
   eq ==> same_relation ==> same_relation as collect_rel_more.
 Proof. u; eauto 8. Qed.
-
 
 
 (******************************************************************************)
@@ -463,7 +482,7 @@ End PropertiesMinus.
 Hint Rewrite minus_false_l minus_false_r minusK : hahn.
 
 (******************************************************************************)
-(** Basic properties of reflexive and transitive closures *)
+(** Basic properties of reflexive/symmetric/transitive closures *)
 (******************************************************************************)
 
 Section PropertiesClos.
@@ -471,13 +490,13 @@ Section PropertiesClos.
   Variable A : Type.
   Implicit Types r : relation A.
 
+  Lemma crE r : r ^? ≡ ⦗fun _ => True⦘ ∪ r.
+  Proof. u. Qed.
+
   Lemma rtE r : r ＊ ≡ ⦗fun _ => True⦘ ∪ r⁺.
   Proof.
     u; rewrite clos_refl_transE in *; tauto.
   Qed.
-
-  Lemma crE r : r ^? ≡ ⦗fun _ => True⦘ ∪ r.
-  Proof. u. Qed.
 
   Lemma rtEE r : r＊ ≡ ⋃n, r ^^ n.
   Proof.
@@ -490,6 +509,15 @@ Section PropertiesClos.
     induction x; ins; [|rewrite IHx];
       unfold eqv_rel, seq; red; ins; desf; vauto.
   Qed.
+
+  Lemma csE r : r^⋈ ≡ r ∪ r⁻¹.
+  Proof. u. Qed.
+
+  Lemma crsE r : r^⋈? ≡ ⦗fun _ => True⦘ ∪ r ∪ r⁻¹.
+  Proof. unfold clos_refl_sym. u. Qed.
+
+  Lemma crsEE r : r^⋈? ≡ ⦗fun _ => True⦘ ∪ r^⋈.
+  Proof. rewrite crsE, csE. u. Qed.
 
   Lemma ct_begin r : r⁺ ≡ r ⨾ r ＊.
   Proof.
@@ -634,6 +662,33 @@ Section PropertiesClos.
   Proof.
     by rewrite unionC, cr_union_l, unionC.
   Qed.
+
+  Lemma cs_union r r' : (r ∪ r')^⋈  ≡ r^⋈ ∪ r'^⋈.
+  Proof. rewrite !csE. u. Qed.
+
+  Lemma crs_union r r' : (r ∪ r')^⋈? ≡ r^⋈? ∪ r'^⋈?.
+  Proof. rewrite !crsE. u. Qed.
+
+  Lemma cs_inter r r' : (r ∩ r')^⋈ ⊆ r^⋈ ∩ r'^⋈.
+  Proof. rewrite !csE. u. Qed.
+
+  Lemma crs_inter r r' : (r ∩ r')^⋈? ⊆ r^⋈? ∩ r'^⋈?.
+  Proof. rewrite !crsE. u. Qed.
+
+  Lemma cs_cross (s s' : A -> Prop) : (s × s')^⋈ ≡ s × s' ∪ s' × s.
+  Proof. rewrite !csE. u. Qed.
+
+  Lemma crs_cross (s s' : A -> Prop) : (s × s')^⋈? ≡ ⦗fun _ => True⦘ ∪ s × s' ∪ s' × s.
+  Proof. rewrite !crsE. u. Qed.
+
+  Lemma cs_restr (s : A -> Prop) r : (restr_rel s r)^⋈ ≡ restr_rel s r^⋈.
+  Proof. rewrite !csE. u. Qed.
+
+  Lemma crs_restr (s : A -> Prop) r : (restr_rel s r)^⋈? ≡ ⦗fun _ => True⦘ ∪ restr_rel s r^⋈.
+  Proof. rewrite !csE, !crsE. u. Qed.
+
+  Lemma restr_of_crs (s : A -> Prop) r : restr_rel s r^⋈? ≡ ⦗s⦘ ∪ restr_rel s r^⋈.
+  Proof. rewrite !csE, !crsE. u. Qed.
 
   Lemma seq_rtE_r r r' : r ⨾ r' ＊ ≡ r ∪ (r ⨾ r') ⨾ r' ＊.
   Proof.
@@ -1136,6 +1191,45 @@ Proof. u; eauto 8. Qed.
 
 Hint Rewrite collect_rel_empty collect_rel_cross : hahn.
 Hint Rewrite collect_rel_union collect_rel_bunion : hahn.
+
+(******************************************************************************)
+(** ** Properties of symmetry *)
+(******************************************************************************)
+
+Section PropertiesSymmetry.
+
+  Variable A : Type.
+  Implicit Type r : relation A.
+  Implicit Type s : A -> Prop.
+
+  Lemma cr_sym r : symmetric r -> symmetric r^?.
+  Proof. u. Qed.
+
+  Lemma cs_sym r : symmetric r^⋈.
+  Proof. rewrite csE. u. Qed.
+
+  Lemma crs_sym r : symmetric r^⋈?.
+  Proof. rewrite crsE. u. Qed.
+
+  Lemma eqv_sym s : symmetric ⦗s⦘.
+  Proof. u. Qed.
+
+  Lemma union_sym r r' : symmetric r -> symmetric r' -> symmetric (r ∪ r').
+  Proof. u. Qed.
+
+  Lemma inter_sym r r' : symmetric r -> symmetric r' -> symmetric (r ∩ r').
+  Proof. u. Qed.
+
+  Lemma minus_sym r r' : symmetric r -> symmetric r' -> symmetric (r \ r').
+  Proof. u. Qed.
+
+  Lemma transp_sym r : symmetric r -> symmetric r⁻¹.
+  Proof. u. Qed.
+
+  Lemma restr_sym s r : symmetric r -> symmetric (restr_rel s r).
+  Proof. u. Qed.
+
+End PropertiesSymmetry.
 
 (******************************************************************************)
 (** Misc properties *)

--- a/HahnEquational.v
+++ b/HahnEquational.v
@@ -1202,7 +1202,10 @@ Section PropertiesSymmetry.
   Implicit Type r : relation A.
   Implicit Type s : A -> Prop.
 
-  Lemma symmetricE r : symmetric r <-> r ≡ r⁻¹.
+  Lemma symmetricE r : symmetric r <-> r ⊆ r⁻¹.
+  Proof. u. Qed.
+
+  Lemma symmetricEE r : symmetric r <-> r ≡ r⁻¹.
   Proof. u. Qed.
 
   Lemma cr_sym r : symmetric r -> symmetric r^?.

--- a/HahnRelationsBasic.v
+++ b/HahnRelationsBasic.v
@@ -102,7 +102,7 @@ Definition cross_rel A (r r' : A -> Prop) := (fun a b => r a /\ r' b).
 Hint Unfold reflexive symmetric transitive inclusion same_relation : unfolderDb. 
 Hint Unfold union transp singl_rel inter_rel minus_rel bunion : unfolderDb.
 Hint Unfold eq_rel eqv_rel eqv_dom_rel restr_rel restr_eq_rel seq map_rel : unfolderDb.
-Hint Unfold clos_refl dom_rel codom_rel cross_rel collect_rel : unfolderDb.
+Hint Unfold clos_refl clos_sym clos_refl_sym dom_rel codom_rel cross_rel collect_rel : unfolderDb.
 Hint Unfold immediate irreflexive acyclic is_total functional : unfolderDb. 
 Hint Unfold antisymmetric strict_partial_order strict_total_order : unfolderDb.
 

--- a/HahnRelationsBasic.v
+++ b/HahnRelationsBasic.v
@@ -51,6 +51,10 @@ Section RelDefs.
 
   Definition clos_refl : relation A := fun x y => x = y \/ r x y.
 
+  Definition clos_sym : relation A := fun x y => r x y \/ r y x.
+
+  Definition clos_refl_sym : relation A := fun x y => x = y \/ r x y \/ r y x.
+
   Definition dom_rel := fun x => exists y, r x y.
   Definition codom_rel := fun y => exists x, r x y.
 
@@ -112,12 +116,16 @@ Notation "⦗ a ⦘" := (eqv_rel a) (format "⦗ a ⦘").
 Notation "∅₂" := (fun _ _ => False).
 Notation "P × Q" := (cross_rel P Q) (at level 29, left associativity).
 
-Notation "a ^?" := (clos_refl a) (at level 1, format "a ^?").
-Notation "a ^^ n" := (pow_rel a n) (at level 1).
+Notation "a ⁻¹" := (transp a) (at level 1, format "a ⁻¹").
 
+Notation "a ^?" := (clos_refl a) (at level 1, format "a ^?").
 Notation "a ⁺" := (clos_trans a) (at level 1, format "a ⁺").
 Notation "a ＊" := (clos_refl_trans a) (at level 1, format "a ＊").
-Notation "a ⁻¹" := (transp a) (at level 1, format "a ⁻¹").
+Notation "a ^⋈" := (clos_sym a) (at level 1, format "a ^⋈").
+Notation "a ^⋈?" := (clos_refl_sym a) (at level 1, format "a ^⋈?").
+
+Notation "a ^^ n" := (pow_rel a n) (at level 1).
+
 Notation "a ⊆ b" := (inclusion a b)  (at level 60).
 Notation "a ≡ b" := (same_relation a b)  (at level 60).
 


### PR DESCRIPTION
1. Definitions of symmetric `clos_sym` and reflexive-symmetric `clos_refl_sym` closures.
2. Notation for them. 
  - "a ^⋈" notation for symmetric closure
  - "a ^⋈?" notation for reflexive-symmetric closure
3. Some useful lemmas about (reflexive-)symmetric closure.
4. Some useful lemmas about symmetry of relations.

  It seems that there is no standard notation for symmetric closure in the literature.
  Thus the choice of notation is debatable.
  A few alternatives considered by me. 

  "a ^=" notation for reflexive-symmetric closure from WeakestMO original paper. 
     The "a ^=" notation is also often used for reflexive closure and thus it is undesirable (might lead to confusion).

  "a ^s" and "a ^s?" notation. It seems that this notation was used previously in some literature [(link)](https://math.stackexchange.com/questions/3244046/notation-for-symmetric-closure-of-a-relation?rq=1). However, I personally like `\bowtie`  ^⋈ notation more.