### PR TITLE
Lemmas about set_collect, collect_rel, set_map, map_rel

### DIFF
--- a/HahnDom.v
+++ b/HahnDom.v
@@ -135,6 +135,22 @@ Section Lemmas.
   Proof. apply set_nonemptyE in N; unfold codom_rel, cross_rel, set_equiv, set_subset; 
          split; ins; desf; eauto. Qed.
 
+  Lemma set_collect_dom :
+    f ↑₁ dom_rel r ≡₁ dom_rel (f ↑ r).
+  Proof. unfolder; split; ins; desf; eauto 10. Qed.
+
+  Lemma set_collect_codom :
+    f ↑₁ codom_rel r ≡₁ codom_rel (f ↑ r).
+  Proof. unfolder; split; ins; desf; eauto 10. Qed.
+
+  Lemma set_map_dom (rr : relation B) :
+    dom_rel (f ↓ rr) ⊆₁ f ↓₁ dom_rel rr.
+  Proof. unfolder; ins; desf; eauto 20. Qed.
+
+  Lemma set_map_codom (rr : relation B) :
+    codom_rel (f ↓ rr) ⊆₁ f ↓₁ codom_rel rr.
+  Proof. unfolder; ins; desf; eauto 10. Qed.
+
   Lemma transp_doma : domb r d -> doma (transp r) d.
   Proof. unfold doma, domb, transp; eauto. Qed.
 

--- a/HahnEquational.v
+++ b/HahnEquational.v
@@ -1032,29 +1032,94 @@ Ltac rel_transp :=
 (** Properties of [map_rel] *)
 (******************************************************************************)
 
-Lemma map_rel_false A B (f : A -> B) :
-  map_rel f ∅₂ ≡ ∅₂.
-Proof. u. Qed.
+Section PropertiesMapRel.
 
-Lemma map_rel_cross A B (f : A -> B) s s' :
-  map_rel f (s × s') ≡ (fun x => s (f x)) × (fun x => s' (f x)).
-Proof. u. Qed.
+  Variable A B C : Type.
+  Implicit Type f : A -> B.
+  Implicit Type d : B -> Prop.
 
-Lemma map_rel_union A B (f : A -> B) r r' :
-  map_rel f (r ∪ r') ≡ map_rel f r ∪ map_rel f r'.
-Proof. u. Qed.
+  Lemma map_rel_compose (f : A -> B) (g : B -> C) r :
+    (g ∘ f) ↓ r ≡ f ↓ (g ↓ r).
+  Proof.
+    unfold compose.
+    repeat autounfold with unfolderDb.
+    ins; splits; ins; splits; desf; eauto 10.
+  Qed.
 
-Lemma map_rel_inter A B (f : A -> B) r r' :
-  map_rel f (r ∩ r') ≡ map_rel f r ∩ map_rel f r'.
-Proof. u. Qed.
+  Lemma map_rel_false f :
+    f ↓ ∅₂ ≡ ∅₂.
+  Proof. u. Qed.
 
-Lemma map_rel_minus A B (f : A -> B) r r' :
-  map_rel f (r \ r') ≡ map_rel f r \ map_rel f r'.
-Proof. u. Qed.
+  Lemma map_rel_false f :
+    f ↓ ∅₂ ≡ ∅₂.
+  Proof. u. Qed.
 
-Lemma map_rel_restr A B (f : A -> B) d r :
-  map_rel f (restr_rel d r) ≡ restr_rel (fun x => d (f x)) (map_rel f r).
-Proof. u. Qed.
+  Lemma map_rel_cross f d d' :
+    f ↓ (d × d') ≡ (f ↓₁ d) × (f ↓₁ d').
+  Proof. u. Qed.
+
+  Lemma map_rel_union f r r' :
+    f ↓ (r ∪ r') ≡ f ↓ r ∪ f ↓ r'.
+  Proof. u. Qed.
+
+  Lemma map_rel_inter f r r' :
+    f ↓ (r ∩ r') ≡ f ↓ r ∩ f ↓ r'.
+  Proof. u. Qed.
+
+  Lemma map_rel_minus f r r' :
+    f ↓ (r \ r') ≡ f ↓ r \ f ↓ r'.
+  Proof. u. Qed.
+
+  Lemma map_rel_restr f d r :
+    f ↓ (restr_rel d r) ≡ restr_rel (f ↓₁ d) (f ↓ r).
+  Proof. u. Qed.
+
+  Lemma map_rel_transp f r :
+    f ↓ r⁻¹ ≡ (f ↓ r)⁻¹.
+  Proof. u; eauto 8. Qed.
+
+  Lemma map_rel_eqv f d :
+    ⦗ f ↓₁ d ⦘ ⊆ f ↓ ⦗ d ⦘.
+  Proof. u; eauto 8. Qed.
+
+  Lemma map_rel_seq f r r' :
+    (f ↓ r) ⨾ (f ↓ r') ⊆ f ↓ (r ⨾ r').
+  Proof. u; eauto. Qed.
+
+  Lemma map_rel_cr f r :
+    (f ↓ r)^? ⊆ f ↓ r^?.
+  Proof. u; eauto 8. Qed.
+
+  Lemma map_rel_ct f r :
+    (f ↓ r)⁺ ⊆ f ↓ r⁺.
+  Proof. 
+    u. induction H.
+    { apply ct_step. eauto. }
+    apply ct_ct. eexists. eauto. 
+  Qed.
+
+  Lemma map_rel_crt f r :
+    (f ↓ r)＊ ⊆ f ↓ r＊.
+  Proof.
+    by rewrite 
+         <- !cr_of_ct,
+         <- map_rel_cr,
+         <- map_rel_ct.
+  Qed.
+
+  Lemma map_rel_irr f r (Irr : irreflexive r):
+    irreflexive (f ↓ r).
+  Proof. u. Qed.
+
+  Lemma map_rel_acyclic f r (ACYC : acyclic r):
+    acyclic (f ↓ r).
+  Proof.
+    unfold acyclic in *.
+    erewrite map_rel_ct.
+    by eapply map_rel_irr.
+  Qed.
+
+End PropertiesMapRel.
 
 (******************************************************************************)
 (** Properties of [pow_rel] *)
@@ -1128,7 +1193,7 @@ Section PropertiesCollectRel.
   Implicit Type s : A -> Prop.
 
   Lemma collect_rel_compose (f : A -> B) (g : B -> C) r :
-    g ↑ (f ↑ r) ≡ (g ∘ f) ↑ r.
+    (g ∘ f) ↑ r ≡ g ↑ (f ↑ r).
   Proof.
     unfold compose.
     repeat autounfold with unfolderDb.

--- a/HahnEquational.v
+++ b/HahnEquational.v
@@ -1050,10 +1050,6 @@ Section PropertiesMapRel.
     f ↓ ∅₂ ≡ ∅₂.
   Proof. u. Qed.
 
-  Lemma map_rel_false f :
-    f ↓ ∅₂ ≡ ∅₂.
-  Proof. u. Qed.
-
   Lemma map_rel_cross f d d' :
     f ↓ (d × d') ≡ (f ↓₁ d) × (f ↓₁ d').
   Proof. u. Qed.

--- a/HahnEquational.v
+++ b/HahnEquational.v
@@ -2,10 +2,12 @@
 (** * Equational properties of relations *)
 (******************************************************************************)
 
-Require Import NPeano Omega Permutation List Setoid.
+Require Import Program.Basics NPeano Omega Permutation List Setoid.
 Require Import HahnBase HahnList HahnRelationsBasic HahnSets.
 
 Set Implicit Arguments.
+
+Local Open Scope program_scope.
 
 (******************************************************************************)
 (** Set up setoid rewriting *)
@@ -1119,20 +1121,92 @@ Hint Rewrite cross_false_l cross_false_r : hahn.
 (** Properties of [collect_rel] *)
 (******************************************************************************)
 
-Lemma collect_rel_empty A B (f : A -> B) : collect_rel f ∅₂ ≡ ∅₂.
-Proof. u. Qed.
+Section PropertiesCollectRel.
 
-Lemma collect_rel_cross A B (f : A -> B) s s' :
-  collect_rel f (s × s') ≡ set_collect f s × set_collect f s'.
-Proof. u; eauto 8. Qed.
+  Variable A B C : Type.
+  Implicit Type f : A -> B.
+  Implicit Type s : A -> Prop.
 
-Lemma collect_rel_union A B (f : A -> B) s s' :
-  collect_rel f (s ∪ s') ≡ collect_rel f s ∪ collect_rel f s'.
-Proof. u; eauto 8. Qed.
+  Lemma collect_rel_compose (f : A -> B) (g : B -> C) r :
+    g ↑ (f ↑ r) ≡ (g ∘ f) ↑ r.
+  Proof.
+    unfold compose.
+    repeat autounfold with unfolderDb.
+    ins; splits; ins; splits; desf; eauto 10.
+  Qed.
 
-Lemma collect_rel_bunion A B (f : A -> B) C (s : C -> Prop) rr :
-  collect_rel f (⋃x ∈ s, rr x) ≡ ⋃x ∈ s, collect_rel f (rr x).
-Proof. u; eauto 8. Qed.
+  Lemma collect_rel_empty f : f ↑ ∅₂ ≡ ∅₂.
+  Proof. u. Qed.
+
+  Lemma collect_rel_singl f x y : f ↑ singl_rel x y ≡ singl_rel (f x) (f y).
+  Proof. u; eauto 8. Qed.
+
+  Lemma collect_rel_cross f s s' :
+    f ↑ (s × s') ≡ (f ↑₁ s) × (f ↑₁ s').
+  Proof. u; eauto 8. Qed.
+
+  Lemma collect_rel_union f r r' :
+    f ↑ (r ∪ r') ≡ f ↑ r ∪ f ↑ r'.
+  Proof. u; eauto 8. Qed.
+
+  Lemma collect_rel_inter f r r' :
+    f ↑ (r ∩ r') ⊆ (f ↑ r) ∩ (f ↑ r').
+  Proof. u; eauto 8. Qed.
+
+  Lemma collect_rel_bunion f (s : C -> Prop) rr :
+    f ↑ (⋃x ∈ s, rr x) ≡ ⋃x ∈ s, f ↑ (rr x).
+  Proof. u; eauto 8. Qed.
+
+  Lemma collect_rel_minus f r r' :
+    f ↑ r \ f ↑ r' ⊆ f ↑ (r \ r').
+  Proof. u; eauto 20. Qed.
+
+  Lemma collect_rel_transp f r :
+    f ↑ r⁻¹ ≡ (f ↑ r)⁻¹.
+  Proof. u; eauto 8. Qed.
+
+  Lemma collect_rel_eqv f s :
+    f ↑ ⦗ s ⦘ ≡ ⦗ f ↑₁ s ⦘.
+  Proof. u; eauto 8. Qed.
+
+  Lemma collect_rel_seq f r r' :
+    f ↑ (r ⨾ r') ⊆ (f ↑ r) ⨾ (f ↑ r').
+  Proof. u; eauto 20. Qed.
+
+  Lemma collect_rel_cr f r :
+    f ↑ r^? ⊆  (f ↑ r)^?.
+  Proof. u; eauto 8. Qed.
+
+  Lemma collect_rel_ct f r :
+    f ↑ r⁺ ⊆ (f ↑ r)⁺.
+  Proof. 
+    u. induction H.
+    { apply ct_step. eauto. }
+    apply ct_ct. eexists. eauto. 
+  Qed.
+
+  Lemma collect_rel_crt f r :
+    f ↑ r＊ ⊆ (f ↑ r)＊.
+  Proof.
+      by rewrite 
+         <- !cr_of_ct,
+         <- collect_rel_ct,
+         <- collect_rel_cr.
+  Qed.
+
+  Lemma collect_rel_irr f r (Irr : irreflexive (f ↑ r)):
+    irreflexive r.
+  Proof. u. eapply Irr. eauto. Qed.
+
+  Lemma collect_rel_acyclic f r (ACYC : acyclic (f ↑ r)):
+    acyclic r.
+  Proof.
+    unfold acyclic in *.
+    eapply collect_rel_irr.
+    eby erewrite collect_rel_ct.
+  Qed.
+
+End PropertiesCollectRel.
 
 Hint Rewrite collect_rel_empty collect_rel_cross : hahn.
 Hint Rewrite collect_rel_union collect_rel_bunion : hahn.

--- a/HahnRelationsBasic.v
+++ b/HahnRelationsBasic.v
@@ -112,6 +112,9 @@ Notation "⦗ a ⦘" := (eqv_rel a) (format "⦗ a ⦘").
 Notation "∅₂" := (fun _ _ => False).
 Notation "P × Q" := (cross_rel P Q) (at level 29, left associativity).
 
+Notation "f ↑ P" := (collect_rel f P) (at level 30).
+Notation "f ↓ Q" := (map_rel f Q) (at level 30).
+
 Notation "a ^?" := (clos_refl a) (at level 1, format "a ^?").
 Notation "a ^^ n" := (pow_rel a n) (at level 1).
 

--- a/HahnSets.v
+++ b/HahnSets.v
@@ -653,6 +653,14 @@ Add Parametric Morphism A B : (@set_collect A B) with signature
   eq ==> set_equiv ==> set_equiv as set_collect_more.
 Proof. repeat autounfold with unfolderDb; splits; ins; desf; eauto. Qed.
 
+Add Parametric Morphism A B : (@set_map A B) with signature
+  eq ==> set_subset ==> set_subset as set_map_mori.
+Proof. repeat autounfold with unfolderDb; splits; ins; desf; eauto. Qed. 
+
+Add Parametric Morphism A B : (@set_map A B) with signature
+  eq ==> set_equiv ==> set_equiv as set_map_more.
+Proof. repeat autounfold with unfolderDb; splits; ins; desf; eauto. Qed. 
+
 Add Parametric Morphism A : (@set_disjoint A) with signature 
   set_subset --> set_subset --> Basics.impl as set_disjoint_mori.
 Proof. red; autounfold with unfolderDb; ins; desf; eauto. Qed.

--- a/HahnSets.v
+++ b/HahnSets.v
@@ -406,6 +406,14 @@ Section SetProperties.
 
   (** Collect *)
 
+  Lemma set_collect_compose (f : A -> B) (g : B -> C) s :
+    (g ∘ f) ↑₁ s ≡₁ g ↑₁ (f ↑₁ s) .
+  Proof.
+    unfold compose.
+    repeat autounfold with unfolderDb.
+    ins; splits; ins; splits; desf; eauto.
+  Qed.
+
   Lemma set_collectE f s : f ↑₁ s ≡₁ set_bunion s (fun x => eq (f x)).
   Proof. u. Qed.
 
@@ -427,14 +435,14 @@ Section SetProperties.
     f ↑₁ (⋃₁x ∈ s, ss x) ≡₁ ⋃₁x ∈ s, f ↑₁ (ss x).
   Proof. u. Qed.
 
-  Lemma set_collect_compose (f : A -> B) (g : B -> C) s :
-    (g ∘ f) ↑₁ s ≡₁ g ↑₁ (f ↑₁ s) .
+  (** Map *)
+
+  Lemma set_map_compose (f : A -> B) (g : B -> C) (d : C -> Prop) :
+    (g ∘ f) ↓₁ d ≡₁ f ↓₁ (g ↓₁ d) .
   Proof. 
     autounfold with unfolderDb. 
     ins; splits; ins; splits; desf; eauto.
   Qed.
-
-  (** Map *)
 
   Lemma set_mapE f d : f ↓₁ d ≡₁ set_bunion d (fun x y => x = f y).
   Proof. split; u. desc. by subst y. Qed.
@@ -456,13 +464,6 @@ Section SetProperties.
   Lemma set_map_bunion f (d : C -> Prop) (dd : C -> B -> Prop) :
     f ↓₁ (⋃₁x ∈ d, dd x) ≡₁ ⋃₁x ∈ d, f ↓₁ (dd x).
   Proof. u. Qed.
-
-  Lemma set_map_compose (f : A -> B) (g : B -> C) (d : C -> Prop) :
-    (g ∘ f) ↓₁ d ≡₁ f ↓₁ (g ↓₁ d) .
-  Proof. 
-    autounfold with unfolderDb. 
-    ins; splits; ins; splits; desf; eauto.
-  Qed.
 
   (** Collect and Map *)
 


### PR DESCRIPTION
Changes in this PR:

1) Added `set_map` by analogy to `map_rel`:

```Coq
Definition set_map f d  := fun x => d (f x).
```

2) Added notation. 

```Coq
Notation "f ↑ P" := (collect_rel f P) (at level 30).
Notation "f ↓ Q" := (map_rel f Q) (at level 30).

Notation "f ↑₁ P" := (set_collect f P) (at level 30).
Notation "f ↓₁ Q" := (set_map f Q) (at level 30).
```

In our earlier development (in [weakestmoToImm](https://github.com/weakmemory/weakestmoToImm/))
we've used different notation: `f □ r` for collect and `f ⋄ r` for map. 
However, my opinion is that the notation we've used initially is not very informative and the new notation is more natural. 

3) Added more lemmas about `set_collect`, `collect_rel`, `set_map`, `map_rel`.

Moreover, during our development, we've noticed that `set_collect`/`set_map` 
(`collect_rel`/`map_rel` corr.) correspond to `map`/`comap` over `A -> Prop` functor. 


```Coq
set_collect : forall A B : Type, (A -> B) -> (A -> Prop) -> B -> Prop
```

```Coq
set_map : forall A B : Type, (A -> B) -> (B -> Prop) -> A -> Prop
```

So the better naming would be `set_map` for `set_collect` and `set_comap` for `set_map`. 
But, I guess, currently it would be painful to change names, since it would break backward compatibility. 