### PR TITLE
Coq 8.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.vo
+*.vok
+*.vos
 *.vio
 *.glob
 *.v.d


### PR DESCRIPTION
Update gitignore to handle .vok and .vos files generated by coq 8.11