### PR TITLE
Update to Coq 8.14

### DIFF
--- a/HahnMinPath.v
+++ b/HahnMinPath.v
@@ -27,7 +27,9 @@ Qed.
 Lemma eqmod_add_idemp_l n i j k :
   (k + i) mod n = (k + j) mod n <-> i mod n = j mod n.
 Proof.
-  destruct (eqP n 0); desf.
+  destruct (eqP n 0).
+  { clarify; simpl; lia. }
+  desf.
   rewrite !(Nat.add_mod k); try done.
   split; [intro L|by intros ->].
   rewrite !(Nat.add_mod_idemp_r) in L; try done.


### PR DESCRIPTION
In Coq 8.14, `desf` does not solve one of the produced subgoals in `eqmod_add_idemp_l`.

The proof has been updated so that this subgoal is solved without `desf`.