### PR TITLE
Make hahn compatible again with Coq 8.13 and *.14, and update the opam file

### DIFF
--- a/HahnWf.v
+++ b/HahnWf.v
@@ -236,7 +236,7 @@ Section finite_support.
     constructor; intros y Rya.
     assert (IN := FS _ Rya).
     apply In_split in IN; desf.
-    eapply H with (y := l1 ++ l2); ins.
+    eapply (H (l1 ++ l2)); ins.
       by rewrite !app_length; simpl; lia.
     assert (Rxa: r x a) by eauto.
     generalize (FS _ Rxa); rewrite !in_app_iff; ins; desf; eauto.

--- a/opam
+++ b/opam
@@ -1,4 +1,4 @@
-opam-version: "1.2"
+opam-version: "2.0"
 name: "coq-hahn"
 version: "1.1"
 maintainer: "Anton Podkopaev <podkoav239@gmail.com>"
@@ -11,5 +11,5 @@ build: [make "-j%{jobs}%"]
 install: [make "-f" "Makefile.coq" "install"]
 remove: ["rm" "-rf" "%{lib}%/coq/user-contrib/hahn"]
 depends: [
-  "coq" { (>= "8.8.1" & < "8.9~") | (= "dev") }
+  "coq" { >= "8.13" }
 ]


### PR DESCRIPTION
With this small fix, users can use Hahn with Coq 8.13 to 8.15 and install it with a plain `opam pin .` in the repository