### PR TITLE
v9.1.1 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *.v.d
 *.aux
 Makefile.coq*
+.Makefile.coq.d
+.lia.cache

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 Makefile.coq*
 .Makefile.coq.d
 .lia.cache
+.coq-native/*

--- a/HahnAcyclic.v
+++ b/HahnAcyclic.v
@@ -2,7 +2,7 @@
 (** * Decomposing paths and cycles *)
 (******************************************************************************)
 
-Require Import Arith micromega.Lia.
+From Stdlib Require Import Arith micromega.Lia.
 Require Import HahnBase HahnList HahnRelationsBasic.
 Require Import HahnEquational HahnMaxElt HahnRewrite.
 Require Import HahnDom HahnMinPath HahnPath.

--- a/HahnAdjacent.v
+++ b/HahnAdjacent.v
@@ -1,6 +1,6 @@
 Require Import HahnBase HahnRelationsBasic.
 Require Import HahnRewrite.
-Require Import Setoid.
+From Stdlib Require Import Setoid.
 Set Implicit Arguments.
 
 Section Defs.

--- a/HahnBase.v
+++ b/HahnBase.v
@@ -10,7 +10,7 @@
 
 Require Import Bool Arith ZArith String.
 Require ClassicalFacts.
-Require Export ClassicalDescription FunctionalExtensionality.
+Require Export ClassicalDescription IndefiniteDescription FunctionalExtensionality.
 
 Open Scope bool_scope.
 Open Scope list_scope.
@@ -509,6 +509,16 @@ Tactic Notation "tertium_non_datur" constr(P) :=
 
 Tactic Notation "tertium_non_datur" constr(P) "as" simple_intropattern(pattern) :=
   destruct (classic P) as pattern; clarify_not.
+  
+(* Tactic for simplifying the goal & context when working with
+   constructive_indefinite_description. *)
+Ltac des_indefinite_description :=
+  repeat match goal with
+           H : context[constructive_indefinite_description ?x ?y] |- _ 
+             => destruct (constructive_indefinite_description x y); simpls
+           | |- context[constructive_indefinite_description ?x ?y] 
+              => destruct (constructive_indefinite_description x y); simpls 
+         end.
 
 (* ************************************************************************** *)
 (** ** Unification helpers *)

--- a/HahnBase.v
+++ b/HahnBase.v
@@ -8,15 +8,18 @@
 
 (** Symbols starting with [hahn__] are internal. *)
 
-Require Import Bool Arith ZArith String.
-Require ClassicalFacts.
-Require Export ClassicalDescription IndefiniteDescription FunctionalExtensionality.
+From Stdlib Require Import Bool Arith ZArith String.
+From Stdlib Require ClassicalFacts.
+From Stdlib Require Export ClassicalDescription IndefiniteDescription FunctionalExtensionality.
 
 Open Scope bool_scope.
 Open Scope list_scope.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
+
+Ltac Tauto.intuition_solver ::= auto with *. (* Forward compatibility. 
+                                                At some point defalt will be changed to just auto. *)
 
 (** Set up hint databases *)
 Create HintDb hahn discriminated.      (* General stuff, used by done *)

--- a/HahnCountable.v
+++ b/HahnCountable.v
@@ -2,7 +2,7 @@
 (** * Countable sets *)
 (******************************************************************************)
 
-Require Import Arith micromega.Lia Setoid IndefiniteDescription ClassicalChoice.
+From Stdlib Require Import Arith micromega.Lia Setoid IndefiniteDescription ClassicalChoice.
 Require Import HahnBase HahnList HahnEquational HahnRewrite.
 Require Import HahnRelationsBasic HahnSets HahnNatExtra.
 Require Import HahnListBefore HahnWf HahnSorted HahnTotalExt.
@@ -32,7 +32,7 @@ Proof.
     by apply in_seq; lia.
   assert (L: findP cond (List.seq 0 (S n)) < S n).
   {
-    rewrite <- (seq_length (S n) 0) at 2.
+    rewrite <- (length_seq (S n) 0) at 2.
     revert IN; generalize (List.seq 0 (S n)).
     induction l; ins; desf; intuition.
   }
@@ -83,7 +83,7 @@ Lemma lt_funI f (ONE: forall x, x < f x) i j (LT: i < j) d :
 Proof.
   revert i LT; induction j; ins; try lia.
   destruct (eqP i j); desf; eauto.
-  eapply lt_trans, ONE; apply IHj; lia.
+  eapply Nat.lt_trans, ONE; apply IHj; lia.
 Qed.
 
 Definition lt_size A i (s : A -> Prop) :=
@@ -411,7 +411,7 @@ Section enum_ext.
     exists l, prefix_of_nat j = prefix_of_nat i ++ l.
   Proof.
     apply le_plus_minus in LEQ; rewrite LEQ; generalize (j - i) as n.
-    clear; intro n; rewrite Nat.add_comm; induction n; ins; desf; eauto using app_nil_end.
+    clear; intro n; rewrite Nat.add_comm; induction n; ins; desf; eauto using app_nil_r.
     by rewrite IHn; eexists; rewrite <- app_assoc.
   Qed.
 
@@ -539,7 +539,7 @@ Section enum_ext.
         exists (length l1).
         destruct (le_lt_dec i (length l1)) as [Y|Y].
           apply prefix_of_nat_prefix in Y; desc.
-          rewrite Y, X, appA, nth_app; desf; try lia.
+          rewrite Y, X, <- app_assoc, nth_app; desf; try lia.
           rewrite Nat.sub_diag; done.
         forward apply (@prefix_of_nat_prefix (length l1) i) as Z; desc; try lia.
         forward apply length_prefix_of_nat with (n := length l1); eauto.
@@ -570,7 +570,7 @@ Section enum_ext.
         exists (length l1).
         destruct (le_lt_dec i (length l1)) as [Y|Y].
           apply prefix_of_nat_prefix in Y; desc.
-          rewrite Y, X, appA, nth_app; desf; try lia.
+          rewrite Y, X, <- app_assoc, nth_app; desf; try lia.
           rewrite Nat.sub_diag; splits; ins.
           assert (length (prefix_of_nat i) <= n).
           { generalize (nodup_prefix_of_nat i),
@@ -604,7 +604,7 @@ Section enum_ext.
 
     assert (Lin : i < n). {
       clear - SUR Li. red in Li; desc.
-      eapply lt_le_trans; eauto.
+      eapply Nat.lt_le_trans; eauto.
       replace n with (length (map f (List.seq 0 n)))
                      by now (rewrite length_map, length_seq).
       apply NoDup_incl_length; try red; ins.

--- a/HahnDom.v
+++ b/HahnDom.v
@@ -1,6 +1,6 @@
 Require Import HahnBase HahnSets HahnRelationsBasic HahnEquational.
 Require Import HahnRewrite.
-Require Import Setoid.
+From Stdlib Require Import Setoid.
 Set Implicit Arguments.
 
 (** * Calculating the (co)domain of a relation *)

--- a/HahnEquational.v
+++ b/HahnEquational.v
@@ -2,7 +2,7 @@
 (** * Equational properties of relations *)
 (******************************************************************************)
 
-Require Import Program.Basics Arith micromega.Lia Permutation List Setoid.
+From Stdlib Require Import Program.Basics Arith micromega.Lia Permutation List Setoid.
 Require Import HahnBase HahnList HahnRelationsBasic HahnSets.
 
 Set Implicit Arguments.
@@ -1561,7 +1561,7 @@ Proof.
   ins; destruct (classic (exists c, r a c /\ r c b)); desf.
   2: by eapply t_step; split; ins; eauto.
   forward (by eapply D'; eauto) as K; apply in_split in K; desf.
-  rewrite app_length in *; ins; rewrite <- plus_n_Sm, <- app_length in *; desf.
+  rewrite length_app in *; ins; rewrite <- plus_n_Sm, <- length_app in *; desf.
   apply t_trans with c; eapply IHn with (dom := l1 ++ l2); ins;
   forward (by eapply (D' c0); eauto);
   rewrite !in_app_iff; ins; desf; eauto; exfalso; eauto.

--- a/HahnFun.v
+++ b/HahnFun.v
@@ -2,7 +2,8 @@
 (** * Function update *)
 (******************************************************************************)
 
-Require Import HahnBase List.
+Require Import HahnBase.
+From Stdlib Require Import List.
 Set Implicit Arguments.
 
 (** Function update *)

--- a/HahnFuneq.v
+++ b/HahnFuneq.v
@@ -1,5 +1,5 @@
 Require Import HahnBase HahnRelationsBasic.
-Require Import Setoid.
+From Stdlib Require Import Setoid.
 Set Implicit Arguments.
 
 Section FunEq.

--- a/HahnLift.v
+++ b/HahnLift.v
@@ -2,8 +2,8 @@
 (** Lifting of relations to partial equivalence classes                       *)
 (******************************************************************************)
 
-Require Import HahnBase HahnSets HahnRelationsBasic.
-Require Import Setoid HahnEquational.
+Require Import HahnBase HahnSets HahnRelationsBasic HahnEquational.
+From Stdlib Require Import Setoid.
 
 Set Implicit Arguments.
 

--- a/HahnList.v
+++ b/HahnList.v
@@ -1136,7 +1136,7 @@ Lemma mk_listE n A (f: nat -> A) :
 Proof.
   induction n; ins; rewrite IHn.
   rewrite seq_split with (x:=n) (y:=S n); try lia.
-  by rewrite map_app, plus_0_r, <- minus_Sn_m, minus_diag.
+  by rewrite map_app, Nat.add_0_r, Nat.sub_succ_l, Nat.sub_diag.
 Qed.
 
 Lemma in_mk_list_iff A (x: A) n f :
@@ -1160,7 +1160,7 @@ Proof.
   induction n; ins; desf; rewrite app_nth; desf;
   rewrite mk_list_length in *; desf; try lia.
     apply nth_overflow; ins; lia.
-  by assert (i = n) by lia; desf; rewrite minus_diag.
+  by assert (i = n) by lia; desf; rewrite Nat.sub_diag.
 Qed.
 
 Definition length_mk_list := mk_list_length.
@@ -1182,7 +1182,7 @@ Fixpoint max_of_list l :=
 Lemma max_of_list_app l l' :
   max_of_list (l ++ l') = max (max_of_list l) (max_of_list l').
 Proof.
-  by induction l; ins; rewrite IHl, Max.max_assoc.
+  by induction l; ins; rewrite IHl, Nat.max_assoc.
 Qed.
 
 (** Miscellaneous *)

--- a/HahnList.v
+++ b/HahnList.v
@@ -3,9 +3,9 @@
 (******************************************************************************)
 
 Require Import HahnBase HahnSets.
-Require Import Arith Lia Setoid Morphisms Sorted.
-Require Import IndefiniteDescription.
-Require Export List Permutation.
+From Stdlib Require Import Arith Lia Setoid Morphisms Sorted.
+From Stdlib Require Import IndefiniteDescription.
+From Stdlib Require Export List Permutation.
 
 Set Implicit Arguments.
 
@@ -16,16 +16,9 @@ Set Implicit Arguments.
 (** Very basic lemmas *)
 (******************************************************************************)
 
-Definition appA := app_ass.
+Definition appA := app_assoc.
 Definition length_nil A : length (@nil A) = 0 := eq_refl.
 Definition length_cons A (a: A) l : length (a :: l) = S (length l) := eq_refl.
-Definition length_app := app_length.
-Definition length_rev := rev_length.
-Definition length_map := map_length.
-Definition length_combine := combine_length.
-Definition length_prod := prod_length.
-Definition length_firstn := firstn_length.
-Definition length_seq := seq_length.
 Definition length_repeat := repeat_length.
 
 #[export]
@@ -164,7 +157,7 @@ Lemma app_cons_eq_snoc A (l1 l2 : list A) a a' l :
 Proof.
   split; ins; desf; [|by rewrite <- app_assoc].
   rewrite app_eq_snoc in H; ins; desf.
-  symmetry in H; rewrite app_cons_eq_cons in H; desf; eauto using app_nil_end.
+  symmetry in H; rewrite app_cons_eq_cons in H; desf; eauto using app_nil_r.
 Qed.
 
 Lemma snoc_eq_nil A (l : list A) a :
@@ -238,7 +231,7 @@ Lemma map_eq_app A B (f : A -> B) l l1' l2' :
   exists l1 l2, l = l1 ++ l2 /\ map f l1 = l1' /\ map f l2 = l2'.
 Proof.
   split; ins; desf; auto using map_app.
-  revert dependent l1'; induction l; destruct l1'; ins; desf.
+  generalize dependent l1'; induction l; destruct l1'; ins; desf.
   - exists nil, nil; ins.
   - eexists nil, (_ :: _); ins.
   - apply IHl in H; desf; eexists (_ :: _), _; ins.
@@ -416,7 +409,7 @@ Proof.
   split; ins.
   eexists (_ ++ _), _; rewrite appA, filterP_app; splits; ins.
   apply filterP_eq_nil in H2; rewrite H2.
-  apply app_nil_end.
+  now rewrite app_nil_r.
 Qed.
 
 Lemma length_filterP A f (l : list A) :
@@ -445,7 +438,7 @@ Qed.
 Lemma flatten_app A (l l' : list (list A)) :
   flatten (l ++ l') = flatten l ++ flatten l'.
 Proof.
-  by induction l; ins; desf; ins; rewrite appA, IHl.
+  by induction l; ins; desf; ins; rewrite <- appA, IHl.
 Qed.
 
 Lemma length_flatten A (l : list (list A)) :
@@ -488,14 +481,14 @@ Lemma rev_filter A f (l : list A) :
   rev (filter f l) = filter f (rev l).
 Proof.
   induction l; ins; desf; ins; rewrite filter_app, IHl; ins; desf; ins.
-  auto using app_nil_end.
+  auto using app_nil_r.
 Qed.
 
 Lemma rev_filterP A f (l : list A) :
   rev (filterP f l) = filterP f (rev l).
 Proof.
   induction l; ins; desf; ins; rewrite filterP_app, IHl; ins; desf; ins.
-  auto using app_nil_end.
+  auto using app_nil_r.
 Qed.
 
 Lemma rev_map A B (f : A -> B) (l : list A) :
@@ -1151,7 +1144,7 @@ Qed.
 Lemma mk_list_length A n (f : nat -> A) :
   length (mk_list n f) = n.
 Proof.
-  induction n; ins; rewrite app_length; ins; lia.
+  induction n; ins; rewrite List.length_app; ins; lia.
 Qed.
 
 Lemma mk_list_nth A i n f (d : A) :
@@ -1204,7 +1197,7 @@ Proof.
          eauto using in_cons.
       by specialize (H0 x); rewrite in_app_iff in *; ins; desf;
          destruct (classic (a = x)); subst; try tauto; exfalso; eauto using in_eq.
-    eexists; rewrite app_ass in *; ins.
+    eexists; rewrite <- app_assoc in *; ins.
     by eapply Permutation_trans, Permutation_middle; eauto.
 
   destruct (IHl l'); eauto; ins.

--- a/HahnListBefore.v
+++ b/HahnListBefore.v
@@ -1,4 +1,5 @@
-Require Import Arith HahnBase HahnList HahnRelationsBasic.
+From Stdlib Require Import Arith.
+Require Import HahnBase HahnList HahnRelationsBasic.
 
 Set Implicit Arguments.
   

--- a/HahnMaxElt.v
+++ b/HahnMaxElt.v
@@ -4,7 +4,7 @@
 
 Require Import HahnBase HahnList HahnSets HahnRelationsBasic.
 Require Import HahnEquational HahnRewrite.
-Require Import Arith Setoid.
+From Stdlib Require Import Arith Setoid.
 
 Set Implicit Arguments.
 

--- a/HahnMinElt.v
+++ b/HahnMinElt.v
@@ -4,7 +4,7 @@
 
 Require Import HahnBase HahnList HahnSets HahnRelationsBasic.
 Require Import HahnEquational HahnRewrite HahnMaxElt.
-Require Import Arith Setoid.
+From Stdlib Require Import Arith Setoid.
 
 Set Implicit Arguments.
 

--- a/HahnMinPath.v
+++ b/HahnMinPath.v
@@ -197,7 +197,7 @@ Proof.
   exists (fun x => f (x mod (S n))), (S n); split; intros; try done.
   - by rewrite Nat.mod_mod.
   - assert (UB := Nat.mod_upper_bound i (S n)).
-    exploit (STEP (i mod S n)); try lia.
+    forward apply (STEP (i mod S n)); try lia.
     rewrite mod_SS_expand; desf; desf. 
       by rewrite !Nat.mod_1_r, ENDS.
     by rewrite Heq0, ENDS.

--- a/HahnMinPath.v
+++ b/HahnMinPath.v
@@ -2,7 +2,7 @@
 (** * Minimal paths and cycles *)
 (******************************************************************************)
 
-Require Import Arith micromega.Lia.
+From Stdlib Require Import Arith micromega.Lia.
 Require Import HahnBase HahnList HahnRelationsBasic HahnRewrite.
 
 Set Implicit Arguments.
@@ -11,9 +11,9 @@ Lemma mod_S_expand i n (NZ : n <> 0) :
   (S i mod n) = if eq_op n 1 then 0 else if eq_op (S (i mod n)) n then 0 else S (i mod n).
 Proof.
   desf; desf;
-    rewrite Nat.add_mod with (a := 1); try done;
+    rewrite Nat.Div0.add_mod with (a := 1); try done;
     rewrite (Nat.mod_small 1); try lia.
-    by simpl; rewrite Heq0, Nat.mod_same.
+    by simpl; rewrite Heq0, Nat.Div0.mod_same.
   assert (UB := Nat.mod_upper_bound i n).
   rewrite (Nat.mod_small (1 + i mod n)); lia.
 Qed.
@@ -30,13 +30,13 @@ Proof.
   destruct (eqP n 0).
   { clarify; simpl; lia. }
   desf.
-  rewrite !(Nat.add_mod k); try done.
+  rewrite !(Nat.Div0.add_mod k); try done.
   split; [intro L|by intros ->].
-  rewrite !(Nat.add_mod_idemp_r) in L; try done.
+  rewrite !(Nat.Div0.add_mod_idemp_r) in L; try done.
   apply f_equal with (f := fun x => ((n - k mod n) + x) mod n) in L.
-  rewrite !Nat.add_mod_idemp_r, !Nat.add_assoc, !Nat.sub_add in L; 
+  rewrite !Nat.Div0.add_mod_idemp_r, !Nat.add_assoc, !Nat.sub_add in L; 
     eauto using Nat.mod_upper_bound, Nat.lt_le_incl. 
-  do 2 (rewrite Nat.add_mod, Nat.mod_same, Nat.add_0_l, Nat.mod_mod in L; try done).
+  do 2 (rewrite Nat.Div0.add_mod, Nat.Div0.mod_same, Nat.add_0_l, Nat.Div0.mod_mod in L; try done).
 Qed.
 
 Lemma eqmod_add_idemp_r n i j k :
@@ -131,7 +131,7 @@ Lemma min_cycle_wlog X (r : relation X) f n (MC : min_cycle_mod r f n)
   exists f, << MC : min_cycle_mod r f n >> /\ << PROP : P (f 0) >>.
 Proof.
   exists (fun x => f (x + i)); unnw; repeat split; ins; try apply MC.
-    by rewrite !(mp_modulo MC (_ + i)), Nat.add_mod_idemp_l; try apply MC.
+    by rewrite !(mp_modulo MC (_ + i)), Nat.Div0.add_mod_idemp_l; try apply MC.
   eby rewrite (min_cycle_step MC) in *; eapply eqmod_add_idemp_r.
 Qed.
 
@@ -189,13 +189,13 @@ Proof.
   rewrite acyclic_minimize1; split; intros A B; destruct A; desc.
   { destruct B as [NZ MOD STEP MIN]; destruct n; try done. 
     exists f, n; unnw; repeat split; intros; try done; eauto.
-    by rewrite (MOD (S n)), Nat.mod_same.
+    by rewrite (MOD (S n)), Nat.Div0.mod_same.
     apply MIN in H.
     destruct (eqP i n), (eqP j (S n)); subst; auto;
-      rewrite ?Nat.mod_same, ?Nat.mod_small in H; lia. 
+      rewrite ?Nat.Div0.mod_same, ?Nat.mod_small in H; lia. 
   }
   exists (fun x => f (x mod (S n))), (S n); split; intros; try done.
-  - by rewrite Nat.mod_mod.
+  - by rewrite Nat.Div0.mod_mod.
   - assert (UB := Nat.mod_upper_bound i (S n)).
     forward apply (STEP (i mod S n)); try lia.
     rewrite mod_SS_expand; desf; desf. 

--- a/HahnNatExtra.v
+++ b/HahnNatExtra.v
@@ -1,4 +1,4 @@
-Require Import NPeano Arith micromega.Lia Setoid HahnBase.
+Require Import Arith micromega.Lia Setoid HahnBase.
 
 Lemma div2_add_double n m :
   Nat.div2 (2 * n + m) = n + Nat.div2 m.
@@ -10,6 +10,12 @@ Qed.
 
 Lemma add_eq_zero n m : n + m = 0 <-> n = 0 /\ m = 0. 
 Proof. lia. Qed.
+
+Lemma le_plus_minus n m : n <= m -> m = n + (m - n).
+Proof.
+  lia.
+Qed.
+  
 
 (*****************************************************************************)
 (** Sum of arithmetic series *)

--- a/HahnNatExtra.v
+++ b/HahnNatExtra.v
@@ -1,4 +1,5 @@
-Require Import Arith micromega.Lia Setoid HahnBase.
+From Stdlib Require Import Arith micromega.Lia Setoid.
+Require Import HahnBase.
 
 Lemma div2_add_double n m :
   Nat.div2 (2 * n + m) = n + Nat.div2 m.
@@ -15,6 +16,17 @@ Lemma le_plus_minus n m : n <= m -> m = n + (m - n).
 Proof.
   lia.
 Qed.
+
+Lemma le_plus_minus_r n m : n <= m -> n + (m - n) = m.
+Proof.
+  lia.
+Qed.
+
+Lemma lt_S_n n m : S n < S m -> n < m.
+Proof.
+  lia.
+Qed.
+
   
 
 (*****************************************************************************)

--- a/HahnOmega.v
+++ b/HahnOmega.v
@@ -3,7 +3,7 @@
 (******************************************************************************)
 
 Require Import HahnBase HahnList.
-Require Import Arith micromega.Lia.
+From Stdlib Require Import Arith micromega.Lia.
 
 Set Implicit Arguments.
 

--- a/HahnPath.v
+++ b/HahnPath.v
@@ -2,7 +2,7 @@
 (** * Decomposing paths and cycles *)
 (******************************************************************************)
 
-Require Import Arith micromega.Lia.
+From Stdlib Require Import Arith micromega.Lia.
 Require Import HahnBase HahnList HahnRelationsBasic.
 Require Import HahnEquational HahnMaxElt HahnRewrite.
 Require Import HahnDom HahnMinPath.
@@ -23,10 +23,10 @@ Proof.
    by destruct l; ins; econs; ins; exfalso; eauto.
   econs; intros b Rba.
   assert (IN:=DOMA _ _ Rba); apply in_split in IN; desf.
-  rewrite app_length in *; ins.
+  rewrite List.length_app in *; ins.
   forward apply (IHn (restr_rel (fun x => x <> b) r) (l1 ++ l2)); 
     eauto using irreflexive_restr, transitive_restr.
-  by rewrite app_length in *; ins; lia.
+  by rewrite List.length_app in *; ins; lia.
   by unfold restr_rel; red; ins; desf; eapply DOMA in REL; rewrite <- Permutation_middle in *; ins; desf; eauto.
 
   clear - Rba ACYC T; unfold restr_rel.
@@ -369,7 +369,7 @@ Proof.
   ins; destruct (classic (exists c, r a c /\ r c b)); desf.
   2: by eapply t_step; split; ins; eauto.
   forward eapply D' as X; eauto; apply in_split in X; desf.
-  rewrite app_length in *; ins; rewrite <- plus_n_Sm, <- app_length in *; desf.
+  rewrite List.length_app in *; ins; rewrite <- plus_n_Sm, <- List.length_app in *; desf.
   apply t_trans with c; eapply IHn with (dom := l1 ++ l2); ins;
   forward eapply (D' c0); eauto;
   rewrite !in_app_iff; ins; desf; eauto; exfalso; eauto.

--- a/HahnRelationsBasic.v
+++ b/HahnRelationsBasic.v
@@ -1,5 +1,5 @@
 Require Import HahnBase HahnList.
-Require Export Relations.
+From Stdlib Require Export Relations.
 
 Set Implicit Arguments.
 

--- a/HahnSets.v
+++ b/HahnSets.v
@@ -3,7 +3,7 @@
 (******************************************************************************)
 
 Require Import HahnBase.
-Require Import Program.Basics List Arith micromega.Lia Relations Setoid Morphisms.
+From Stdlib Require Import Program.Basics List Arith micromega.Lia Relations Setoid Morphisms.
 
 Set Implicit Arguments.
 

--- a/HahnSorted.v
+++ b/HahnSorted.v
@@ -3,7 +3,7 @@
 (******************************************************************************)
 
 Require Import HahnBase HahnSets HahnList HahnRelationsBasic HahnEquational.
-Require Export Sorted Setoid.
+From Stdlib Require Export Sorted Setoid.
 
 Set Implicit Arguments.
 

--- a/HahnTotalExt.v
+++ b/HahnTotalExt.v
@@ -2,7 +2,7 @@
 (** * Extension of a partial order to a total order *)
 (******************************************************************************)
 
-Require Import Arith micromega.Lia Setoid.
+From Stdlib Require Import Arith micromega.Lia Setoid.
 Require Import HahnBase HahnList HahnRelationsBasic HahnEquational HahnRewrite.
 Require Import HahnSets HahnMaxElt.
 Require Import Zorn.
@@ -195,7 +195,7 @@ Proof.
   desc; apply in_split in INa; desf.
   assert(exists b, s ＊ a1 b /\ max_elt s b).
     { eapply (H (l1 ++ l2)).
-      * unfold ltof; rewrite !app_length; simpl; lia.
+      * unfold ltof; rewrite !List.length_app; simpl; lia.
       * ins.
         assert(INc: In c (l1 ++ a :: l2)).
           by eapply DOM; eapply rt_trans; vauto.
@@ -421,7 +421,8 @@ Proof.
   assert (MM: M ⊆ M') by (unfolder; ins; desf; eauto).
   assert (M'OK: R ⊆ M' /\ strict_partial_order M').
   { split; [eby eapply inclusion_trans |].
-    split; red; ins; desf; eauto 8 using (proj1 PO), (proj2 PO).
+    destruct PO as [IRR TRANS].
+    split; red; ins; desf; eauto 8 using IRR, TRANS.
   }
   specialize (MAX (exist _ M' M'OK) MM); ins.
   apply INCOMP, MAX; desf; eauto.

--- a/HahnTrace.v
+++ b/HahnTrace.v
@@ -4,7 +4,7 @@
 
 Require Import HahnBase HahnList HahnSets HahnRelationsBasic.
 Require Import HahnOmega HahnWf.
-Require Import Arith micromega.Lia IndefiniteDescription.
+From Stdlib Require Import Arith micromega.Lia IndefiniteDescription.
 
 Set Implicit Arguments.
 
@@ -394,10 +394,10 @@ Proof.
       do 2 f_equal.
       eapply filterP_map_seq_eq; simpl; eauto.
       ins; forward apply (l0 (length l + i)); desf; try lia.
-        by rewrite minus_plus.
+        by rewrite Nat.add_simpl_l.
       ins; eapply l1 in H; lia.
     - eapply map_trace_prepend_lt with (fl := fl) in l2; desf.
-      rewrite l4, filterP_app, appA; clear l4.
+      rewrite l4, filterP_app, <- app_assoc; clear l4.
       f_equal.
       symmetry; rewrite app_eq_prefix, app_eq_nil, ?filterP_eq_nil.
       remember (a :: l'') as l; clear a l'' Heql.
@@ -465,15 +465,15 @@ Proof.
     destruct (IndefiniteDescription.constructive_indefinite_description);
       ins; desf.
     apply nth_filterP with (d := d) in LT; desf.
-    rewrite map_length, seq_length in *; ins.
-    exists n; splits; try rewrite map_length, seq_length; ins.
+    rewrite List.length_map, List.length_seq in *; ins.
+    exists n; splits; try rewrite List.length_map, List.length_seq; ins.
     rewrite LT0, nth_indep with (d' := fl 0); ins.
     rewrite map_nth, seq_nth; ins.
-    rewrite map_length, seq_length; ins.
+    rewrite List.length_map, List.length_seq; ins.
     do 2 f_equal; apply map_ext_in; ins; in_simp.
     rewrite nth_indep with (d' := fl 0); ins.
     rewrite map_nth, seq_nth; ins; lia.
-    rewrite map_length, seq_length; ins; lia.
+    rewrite List.length_map, List.length_seq; ins; lia.
   }
   destruct set_infinite_natE with (n := i) as (m & F & NF).
   exists m; desf.
@@ -496,7 +496,7 @@ Proof.
     destruct (IndefiniteDescription.constructive_indefinite_description);
       ins; desf.
     clear LT; assert (LT := l _ F); ins.
-    rewrite seqS, (seq_split0 LT), appA, map_app, filterP_app.
+    rewrite seqS, (seq_split0 LT), <- app_assoc, map_app, filterP_app.
     rewrite app_nth2, Nat.sub_diag; ins; desf.
   }
   destruct (IndefiniteDescription.constructive_indefinite_description); ins.
@@ -533,7 +533,7 @@ Qed.
 Lemma trace_prefix_refl A (t : trace A) :
   trace_prefix t t.
 Proof.
-  destruct t; ins; eauto using app_nil_end.
+  destruct t; ins; eauto using app_nil_r.
 Qed.
 
 Lemma trace_prefix_trans A (t t' t'' : trace A) :
@@ -542,7 +542,7 @@ Lemma trace_prefix_trans A (t t' t'' : trace A) :
   trace_prefix t t''.
 Proof.
   destruct t, t', t''; ins; desf; try rewrite <- H0; eauto.
-    by rewrite appA; vauto.
+    by rewrite <- app_assoc; vauto.
   forward apply H0 with (i := i) (d := d);
     rewrite ?length_app, ?nth_app;
     ins; desf; lia.

--- a/HahnWf.v
+++ b/HahnWf.v
@@ -236,7 +236,7 @@ Section finite_support.
     constructor; intros y Rya.
     assert (IN := FS _ Rya).
     apply In_split in IN; desf.
-    eapply H with (y0 := l1 ++ l2); ins.
+    eapply H with (y := l1 ++ l2); ins.
       by rewrite !app_length; simpl; lia.
     assert (Rxa: r x a) by eauto.
     generalize (FS _ Rxa); rewrite !in_app_iff; ins; desf; eauto.

--- a/HahnWf.v
+++ b/HahnWf.v
@@ -2,8 +2,8 @@
 (** * Well-founded and finitely supported relations *)
 (******************************************************************************)
 
-Require Import Arith micromega.Lia Setoid Morphisms Wf_nat.
-Require Import HahnBase HahnList HahnSets HahnRelationsBasic.
+From Stdlib Require Import Arith micromega.Lia Setoid Morphisms Wf_nat.
+Require Import HahnBase HahnNatExtra HahnList HahnSets HahnRelationsBasic.
 Require Import HahnEquational HahnRewrite HahnDom.
 
 Set Implicit Arguments.
@@ -237,7 +237,7 @@ Section finite_support.
     assert (IN := FS _ Rya).
     apply In_split in IN; desf.
     eapply (H (l1 ++ l2)); ins.
-      by rewrite !app_length; simpl; lia.
+      by rewrite !List.length_app; simpl; lia.
     assert (Rxa: r x a) by eauto.
     generalize (FS _ Rxa); rewrite !in_app_iff; ins; desf; eauto.
     exfalso; eauto.
@@ -259,7 +259,7 @@ Section finite_support.
     tertium_non_datur (immediate r x y) as [|NIMM]; vauto.
     assert (N := M _ NIMM NIMM0); apply In_split in N; desf.
     apply t_trans with (y := n); eapply H with (y := l1 ++ l2); ins.
-    1,3: by rewrite !app_length; simpl; lia.
+    1,3: by rewrite !List.length_app; simpl; lia.
     - apply M in H1; eauto; rewrite !in_app_iff in *; ins; desf; eauto.
       exfalso; eauto.
     - apply M in H2; eauto; rewrite !in_app_iff in *; ins; desf; eauto.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ about lists and binary relations.
 
 ## Build
 
-- Install [Coq](http://coq.inria.fr) 8.14
+- Install [Coq](http://coq.inria.fr) 8.15
 - make
 
 ## Use

--- a/Zorn.v
+++ b/Zorn.v
@@ -1,11 +1,12 @@
 (** A formalization of Zorn's lemma. *)
 (** Main author:  Johannes Kloos. *)
 
-From Coq Require Import Relations Equivalence Morphisms Utf8.
-From Coq Require Import ChoiceFacts ClassicalFacts.
-From Coq.Program Require Import Basics.
+Require Import HahnBase.
+From Stdlib Require Import Relations Equivalence Morphisms Utf8.
+From Stdlib Require Import ChoiceFacts ClassicalFacts.
+From Stdlib.Program Require Import Basics.
 
-From Coq.Logic Require Import SetoidChoice.
+From Stdlib.Logic Require Import SetoidChoice.
 
 Module Private.
   Class Le A := le: relation A.
@@ -712,7 +713,7 @@ Section Theorems.
       S_proper:> Proper (eqA ==> iff) S;
       R_strict:> StrictOrder R;
       R_wellfounded: well_founded R;
-      R_proper:> Proper (eqA ==> eqA ==> iff) R;
+      R_proper: Proper (eqA ==> eqA ==> iff) R;
       R_carrier_correct: ∀ x y, R x y → S x ∧ S y;
       R_carrier_complete: ∀ x y, S x → S y → eqA x y ∨ R x y ∨ R y x
     }.

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,3 +1,4 @@
+-arg "-set Warnings=-notation-incompatible-prefix"  # Suppressing a warning regarding ⟪ _ ⟫ and ⟪ _ : _ ⟫ notations.
 -R . hahn
 Hahn.v
 HahnBase.v HahnFun.v HahnSets.v HahnList.v HahnNatExtra.v


### PR DESCRIPTION
**Compatibility with Rocq 9.1.1.** Dealt with deprecation warnings too.

I also set an option in _CoqProject to not print a warning regarding the ⟪ _ : _ ⟫ and ⟪ _ ⟫ notations. It's not an actual issue, since one of those is only-printing.